### PR TITLE
Add initial flow config for new-project-template

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,48 @@
+[ignore]
+
+# We fork some components by platform.
+.*/*[.]android.js
+
+# Ignore templates with `@flow` in header
+.*/local-cli/generator.*
+
+# Ignore malformed json
+.*/node_modules/y18n/test/.*\.json
+
+# Ignore duplicate module providers
+# For RN Apps installed via npm, "Libraries" folder is inside node_modules/react-native but in the source repo it is in the root
+.*/Libraries/react-native/React.js
+.*/Libraries/react-native/ReactNative.js
+.*/Libraries/Components/StaticContainer.js
+.*/node_modules/jest-runtime/build/__tests__/.*
+.*/node_modules/fbemitter/lib/.*
+
+[include]
+
+[libs]
+node_modules/react-native/Libraries/react-native/react-native-interface.js
+node_modules/react-native/flow
+
+[options]
+module.system=haste
+
+esproposal.decorators=ignore
+esproposal.class_static_fields=enable
+esproposal.class_instance_fields=enable
+esproposal.export_star_as=enable
+
+unsafe.enable_getters_and_setters=true
+
+module.name_mapper='^image![a-zA-Z0-9$_-]+$' -> 'GlobalImageStub'
+module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
+
+suppress_type=$FlowIssue
+suppress_type=$FlowFixMe
+suppress_type=$FixMe
+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(3[0-2]\\|[1-2][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(3[0-2]\\|1[0-9]\\|[1-2][0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
+
+[version]
+^0.30.0

--- a/main.js
+++ b/main.js
@@ -1,3 +1,7 @@
+/**
+ * @flow
+ */
+
 import Exponent from 'exponent';
 import React from 'react';
 import {
@@ -34,6 +38,7 @@ class AppContainer extends React.Component {
           require('./assets/images/exponent-wordmark.png'),
         ],
         fonts: [
+          // $FlowFixMe: suppressing this error until RelativeFontStub exists
           {'space-mono': require('./assets/fonts/SpaceMono-Regular.ttf')},
         ],
       });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "@exponent/vector-icons": "^1.0.1",
     "exponent": "^10.0.0",
     "react": "~15.3.2",
-    "react-native": "github:exponentjs/react-native#sdk-10.1.2"
+    "react-native": "github:exponentjs/react-native#sdk-10.1.4"
+  },
+  "devDependencies": {
+    "flow-bin": "^0.30.0"
   }
 }


### PR DESCRIPTION
Setting this up so we can flow-enable all the other files too. I've only added `main.js` for now.

This addresses https://github.com/exponentjs/new-project-template/issues/2

There are currently 3 errors.

```
$ ./node_modules/.bin/flow check
node_modules/react-native-tab-view/src/TabViewTransitioner.js:94
 94:     this._transitionTo(this.props.navigationState.index);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `_transitionTo`
 94:     this._transitionTo(this.props.navigationState.index);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
145:   _transitionTo = (toValue: number, callback: Function) => {
                                                   ^^^^^^^^ function type

node_modules/react-native/Libraries/Components/Touchable/TouchableBounce.js:91
 91:       useNativeDriver: Platform.OS === 'android',
                            ^^^^^^^^ identifier `Platform`. Could not resolve name

node_modules/react-native/Libraries/NavigationExperimental/NavigationTransitioner.js:210
210:   _onTransitionEnd({finished}): void {
                        ^^^^^^^^^^ destructuring. Missing annotation


Found 3 errors
```

Resolutions for these three errors:
1. Merged, waiting for release: https://github.com/react-native-community/react-native-tab-view/pull/30
2. Merged, released as sdk-10.1.4: https://github.com/exponentjs/react-native/pull/6
3. Merged, released as sdk-10.1.4: Fixes https://github.com/exponentjs/react-native/commit/ac29663812a2b0c9c72ae8d43696e05a6eda24eb
