### PR TITLE
Update react-navigation to v3 

### DIFF
--- a/__tests__/App-test.js
+++ b/__tests__/App-test.js
@@ -2,12 +2,12 @@ import 'react-native';
 import React from 'react';
 import App from '../App';
 import renderer from 'react-test-renderer';
-import NavigationTestUtils from 'react-navigation/NavigationTestUtils';
+import { _TESTING_ONLY_reset_container_count } from '@react-navigation/native/src/createAppContainer';
 
 describe('App snapshot', () => {
   jest.useFakeTimers();
   beforeEach(() => {
-    NavigationTestUtils.resetInternalState();
+    _TESTING_ONLY_reset_container_count();
   });
 
   it('renders the loading screen', async () => {

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { createSwitchNavigator } from 'react-navigation';
+import { createAppContainer, createSwitchNavigator } from 'react-navigation';
 
 import MainTabNavigator from './MainTabNavigator';
 
-export default createSwitchNavigator({
+export default createAppContainer(createSwitchNavigator({
   // You could add another route here for authentication.
   // Read more at https://reactnavigation.org/docs/en/auth-flow.html
   Main: MainTabNavigator,
-});
+}));

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   },
   "dependencies": {
     "@expo/samples": "2.1.1",
-    "expo": "^31.0.2",
+    "expo": "^31.0.5",
     "react": "16.5.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-31.0.0.tar.gz",
-    "react-navigation": "^2.18.2"
+    "react-navigation": "^3.0.0"
   },
   "devDependencies": {
     "babel-preset-expo": "^5.0.0",


### PR DESCRIPTION
* Update react-navigation to v3
  * at navigation/AppNavigator.js
  * `__tests__/App-test.js`
    * `import NavigationTestUtils...` -> `import { _TESTING_ONLY_reset_container_count } from '@react-navigation/native/src/createAppContainer';`

By the way I submitted [react-navigation PR](https://github.com/react-navigation/react-navigation/pull/5266) that is NavigationTestUtils error.
So this PR will merged, I submit PR on this repository again.