### PR TITLE
Update react-navigation v3.0.1

### DIFF
--- a/__tests__/App-test.js
+++ b/__tests__/App-test.js
@@ -2,12 +2,12 @@ import 'react-native';
 import React from 'react';
 import App from '../App';
 import renderer from 'react-test-renderer';
-import { _TESTING_ONLY_reset_container_count } from '@react-navigation/native/src/createAppContainer';
+import NavigationTestUtils from 'react-navigation/NavigationTestUtils';
 
 describe('App snapshot', () => {
   jest.useFakeTimers();
   beforeEach(() => {
-    _TESTING_ONLY_reset_container_count();
+    NavigationTestUtils.resetInternalState();
   });
 
   it('renders the loading screen', async () => {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "expo": "^31.0.5",
     "react": "16.5.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-31.0.0.tar.gz",
-    "react-navigation": "^3.0.0"
+    "react-navigation": "^3.0.1"
   },
   "devDependencies": {
     "babel-preset-expo": "^5.0.0",


### PR DESCRIPTION
related to https://github.com/expo/new-project-template/pull/13 and https://github.com/react-navigation/react-navigation/pull/5266.
Fixed import from `@react-navigation/native/src/createAppContainer` -> `react-navigation/NavigationTestUtils` at `__tests__/App-test.js`